### PR TITLE
Implement database/sql's Scanner interface. Fixes #5

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -1,0 +1,40 @@
+// Copyright 2015 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uuid
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Scan implements sql.Scanner so UUIDs can be read from databases transparently
+// Currently, database types that map to string and []byte are supported. Please
+// consult database-specific driver documentation for matching types.
+func (uuid *UUID) Scan(src interface{}) error {
+	switch src.(type) {
+	case string:
+		// see uuid.Parse for required string format
+		parsed := Parse(src.(string))
+
+		if parsed == nil {
+			return errors.New("Scan: invalid UUID format")
+		}
+
+		*uuid = parsed
+	case []byte:
+		// assumes a simple slice of bytes, just check validity and store
+		u := UUID(src.([]byte))
+
+		if u.Variant() == Invalid {
+			return errors.New("Scan: invalid UUID format")
+		}
+
+		*uuid = u
+	default:
+		return fmt.Errorf("Scan: unable to scan type %T into UUID", src)
+	}
+
+	return nil
+}

--- a/sql_test.go
+++ b/sql_test.go
@@ -1,0 +1,53 @@
+// Copyright 2015 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uuid
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScan(t *testing.T) {
+	var stringTest string = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+	var byteTest []byte = Parse(stringTest)
+	var badTypeTest int = 6
+	var invalidTest string = "f47ac10b-58cc-0372-8567-0e02b2c3d4"
+	var invalidByteTest []byte = Parse(invalidTest)
+
+	var uuid UUID
+	err := (&uuid).Scan(stringTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = (&uuid).Scan(byteTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = (&uuid).Scan(badTypeTest)
+	if err == nil {
+		t.Error("int correctly parsed and shouldn't have")
+	}
+	if !strings.Contains(err.Error(), "unable to scan type") {
+		t.Error("attempting to parse an int returned an incorrect error message")
+	}
+
+	err = (&uuid).Scan(invalidTest)
+	if err == nil {
+		t.Error("invalid uuid was parsed without error")
+	}
+	if !strings.Contains(err.Error(), "invalid UUID") {
+		t.Error("attempting to parse an invalid UUID returned an incorrect error message")
+	}
+
+	err = (&uuid).Scan(invalidByteTest)
+	if err == nil {
+		t.Error("invalid byte uuid was parsed without error")
+	}
+	if !strings.Contains(err.Error(), "invalid UUID") {
+		t.Error("attempting to parse an invalid byte UUID returned an incorrect error message")
+	}
+}


### PR DESCRIPTION
Hi! This PR adds an implementation of [sql.Scanner](http://godoc.org/database/sql#Scanner) for convenience when working with uuids in SQL databases. sql.Scanner allows the reading of uuid values from a database directly into a uuid.UUID. 

The implementation of sql.Scanner provided can read values as strings (assumed to be in the format uuid.Parse accepts) or plain byte slices. 

I've written test cases that provide full coverage and have tested this out with sqlite3 using a test harness that I can provide if you're interested.

Please let me know if you have any questions or if you would like me to change anything about the implementation.