### PR TITLE
Add support for driver.Valuer.

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -5,6 +5,7 @@
 package uuid
 
 import (
+	"database/sql/driver"
 	"errors"
 	"fmt"
 )
@@ -55,4 +56,11 @@ func (uuid *UUID) Scan(src interface{}) error {
 	}
 
 	return nil
+}
+
+// Value implements sql.Valuer so that UUIDs can be written to databases
+// transparently. Currently, UUIDs map map to strings. Please consult
+// database-specific driver documentation for matching types.
+func (uuid *UUID) Value() (driver.Value, error) {
+	return uuid.String(), nil
 }

--- a/sql.go
+++ b/sql.go
@@ -61,6 +61,6 @@ func (uuid *UUID) Scan(src interface{}) error {
 // Value implements sql.Valuer so that UUIDs can be written to databases
 // transparently. Currently, UUIDs map map to strings. Please consult
 // database-specific driver documentation for matching types.
-func (uuid *UUID) Value() (driver.Value, error) {
+func (uuid UUID) Value() (driver.Value, error) {
 	return uuid.String(), nil
 }

--- a/sql.go
+++ b/sql.go
@@ -59,7 +59,7 @@ func (uuid *UUID) Scan(src interface{}) error {
 }
 
 // Value implements sql.Valuer so that UUIDs can be written to databases
-// transparently. Currently, UUIDs map map to strings. Please consult
+// transparently. Currently, UUIDs map to strings. Please consult
 // database-specific driver documentation for matching types.
 func (uuid UUID) Value() (driver.Value, error) {
 	return uuid.String(), nil

--- a/sql_test.go
+++ b/sql_test.go
@@ -56,3 +56,12 @@ func TestScan(t *testing.T) {
 		t.Error("attempting to parse an invalid byte UUID returned an incorrect error message")
 	}
 }
+
+func TestValue(t *testing.T) {
+	stringTest := "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+	uuid := Parse(stringTest)
+	val, _ := uuid.Value()
+	if val != stringTest {
+		t.Error("Value() did not return expected string")
+	}
+}


### PR DESCRIPTION
It just returns a string, but that should be recognizable by any database that
supports UUIDs, since it's the standard format.