### PR TITLE
altered uuid.Scan() so that it allows for empty UUIDs to be read ...

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -15,6 +15,11 @@ import (
 func (uuid *UUID) Scan(src interface{}) error {
 	switch src.(type) {
 	case string:
+		// if an empty UUID comes from a table, we return a null UUID
+		if src.(string) == "" {
+			return nil
+		}
+
 		// see uuid.Parse for required string format
 		parsed := Parse(src.(string))
 
@@ -25,6 +30,11 @@ func (uuid *UUID) Scan(src interface{}) error {
 		*uuid = parsed
 	case []byte:
 		b := src.([]byte)
+
+		// if an empty UUID comes from a table, we return a null UUID
+		if len(b) == 0 {
+			return nil
+		}
 
 		// assumes a simple slice of bytes if 16 bytes
 		// otherwise attempts to parse


### PR DESCRIPTION
... properly (returning a null UUID value)

I have a table that has an "id" (the UUID field) and a "parent_id" (the UUID of this row's parent, like a tree). Sometimes the "parent_id" will be empty (null string) meaning it has no parents, it is a parent node itself. Scanning an empty UUID column was returning an error and that broke the Scan(), keeping the record from being scanned properly into a structure.