### PR TITLE
Array conversions

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -21,6 +21,12 @@ func (uuid Array) UUID() UUID {
 	return uuid[:]
 }
 
+// String returns the string representation of uuid,
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (uuid Array) String() string {
+	return uuid.UUID().String()
+}
+
 // A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
 // 4122.
 type UUID []byte

--- a/uuid.go
+++ b/uuid.go
@@ -13,6 +13,14 @@ import (
 	"strings"
 )
 
+// Array is a pass-by-value UUID that can be used as an effecient key in a map.
+type Array [16]byte
+
+// UUID converts uuid into a slice.
+func (uuid Array) UUID() UUID {
+	return uuid[:]
+}
+
 // A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
 // 4122.
 type UUID []byte
@@ -74,6 +82,17 @@ func Parse(s string) UUID {
 // Equal returns true if uuid1 and uuid2 are equal.
 func Equal(uuid1, uuid2 UUID) bool {
 	return bytes.Equal(uuid1, uuid2)
+}
+
+// Array returns an array representation of uuid that can be used as a map key.
+// Array panics if uuid is not valid.
+func (uuid UUID) Array() Array {
+	if len(uuid) != 16 {
+		panic("invalid uuid")
+	}
+	var a Array
+	copy(a[:], uuid)
+	return a
 }
 
 // String returns the string form of uuid, xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -300,7 +300,7 @@ func TestNode(t *testing.T) {
 		t.Error("nodeid is all zeros")
 	}
 
-	id := []byte{1,2,3,4,5,6,7,8}
+	id := []byte{1, 2, 3, 4, 5, 6, 7, 8}
 	SetNodeID(id)
 	ni = NodeID()
 	if !bytes.Equal(ni, id[:6]) {
@@ -431,6 +431,41 @@ func TestBadRand(t *testing.T) {
 	}
 }
 
+func TestUUID_Array(t *testing.T) {
+	uuid := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+	expect := []byte{
+		0xf4, 0x7a, 0xc1, 0x0b,
+		0x58, 0xcc,
+		0x03, 0x72,
+		0x85, 0x67,
+		0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79,
+	}
+	if uuid == nil {
+		t.Fatal("invalid uuid")
+	}
+	array := uuid.Array()
+	if !bytes.Equal(array[:], expect) {
+		t.Fatal("invalid array")
+	}
+}
+
+func TestArray_UUID(t *testing.T) {
+	array := Array{
+		0xf4, 0x7a, 0xc1, 0x0b,
+		0x58, 0xcc,
+		0x03, 0x72,
+		0x85, 0x67,
+		0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79,
+	}
+	expect := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+	if expect == nil {
+		t.Fatal("invalid uuid")
+	}
+	if !bytes.Equal(array.UUID(), expect) {
+		t.Fatal("invalid uuid")
+	}
+}
+
 func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		uuid := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
@@ -465,6 +500,45 @@ func BenchmarkUUID_URN(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		if uuid.URN() == "" {
+			b.Fatal("invalid uuid")
+		}
+	}
+}
+
+func BenchmarkUUID_Array(b *testing.B) {
+	uuid := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+	expect := []byte{
+		0xf4, 0x7a, 0xc1, 0x0b,
+		0x58, 0xcc,
+		0x03, 0x72,
+		0x85, 0x67,
+		0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79,
+	}
+	if uuid == nil {
+		b.Fatal("invalid uuid")
+	}
+	for i := 0; i < b.N; i++ {
+		array := uuid.Array()
+		if !bytes.Equal(array[:], expect) {
+			b.Fatal("invalid array")
+		}
+	}
+}
+
+func BenchmarkArray_UUID(b *testing.B) {
+	array := Array{
+		0xf4, 0x7a, 0xc1, 0x0b,
+		0x58, 0xcc,
+		0x03, 0x72,
+		0x85, 0x67,
+		0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79,
+	}
+	expect := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+	if expect == nil {
+		b.Fatal("invalid uuid")
+	}
+	for i := 0; i < b.N; i++ {
+		if !bytes.Equal(array.UUID(), expect) {
 			b.Fatal("invalid uuid")
 		}
 	}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -432,19 +432,18 @@ func TestBadRand(t *testing.T) {
 }
 
 func TestUUID_Array(t *testing.T) {
-	uuid := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
-	expect := []byte{
+	expect := Array{
 		0xf4, 0x7a, 0xc1, 0x0b,
 		0x58, 0xcc,
 		0x03, 0x72,
 		0x85, 0x67,
 		0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79,
 	}
+	uuid := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
 	if uuid == nil {
 		t.Fatal("invalid uuid")
 	}
-	array := uuid.Array()
-	if !bytes.Equal(array[:], expect) {
+	if uuid.Array() != expect {
 		t.Fatal("invalid array")
 	}
 }
@@ -506,20 +505,19 @@ func BenchmarkUUID_URN(b *testing.B) {
 }
 
 func BenchmarkUUID_Array(b *testing.B) {
-	uuid := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
-	expect := []byte{
+	expect := Array{
 		0xf4, 0x7a, 0xc1, 0x0b,
 		0x58, 0xcc,
 		0x03, 0x72,
 		0x85, 0x67,
 		0x0e, 0x02, 0xb2, 0xc3, 0xd4, 0x79,
 	}
+	uuid := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
 	if uuid == nil {
 		b.Fatal("invalid uuid")
 	}
 	for i := 0; i < b.N; i++ {
-		array := uuid.Array()
-		if !bytes.Equal(array[:], expect) {
+		if uuid.Array() != expect {
 			b.Fatal("invalid array")
 		}
 	}


### PR DESCRIPTION
Changes discussed in #3 to achieve efficient map keys. The `Array.String()` method was added for convenience.