### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.4.3
   - 1.5.3
-  - release
   - tip
 
 script:


### PR DESCRIPTION
The go version `release` does not resolve to a valid go version. In previous builds we can see this

```
$ eval "$(gimme release)"
I don't have any idea what to do with 'release'.
  (using type 'auto')
```

Travis has since changed their scripts and this now dies

```
$ GIMME_OUTPUT=$(gimme release) && eval "$GIMME_OUTPUT"
I don't have any idea what to do with 'release'.
  (using type 'auto')
The command "GIMME_OUTPUT=$(gimme release) && eval "$GIMME_OUTPUT"" failed and exited with 1 during .
```

I've just removed `release`.