### PR TITLE
Fix data race 

### DIFF
--- a/node.go
+++ b/node.go
@@ -32,6 +32,9 @@ func NodeInterface() string {
 func SetNodeInterface(name string) bool {
 	defer nodeMu.Unlock()
 	nodeMu.Lock()
+	if nodeID != nil {
+		return true
+	}
 	return setNodeInterface(name)
 }
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -277,9 +277,11 @@ func TestNode(t *testing.T) {
 	if ni := NodeInterface(); ni != "" {
 		t.Errorf("NodeInterface got %q, want %q", ni, "")
 	}
+	nodeID = nil // Reset global state for next test
 	if SetNodeInterface("xyzzy") {
 		t.Error("SetNodeInterface succeeded on a bad interface name")
 	}
+	nodeID = nil // Reset global state for next test
 	if !SetNodeInterface("") {
 		t.Error("SetNodeInterface failed")
 	}
@@ -355,6 +357,7 @@ func TestSHA1(t *testing.T) {
 
 func TestNodeID(t *testing.T) {
 	nid := []byte{1, 2, 3, 4, 5, 6}
+	nodeID = nil // Reset global state for next test
 	SetNodeInterface("")
 	s := NodeInterface()
 	if runtime.GOARCH != "js" {

--- a/version1.go
+++ b/version1.go
@@ -15,9 +15,7 @@ import (
 // SetClockSequence then it will be set automatically.  If GetTime fails to
 // return the current NewUUID returns nil.
 func NewUUID() UUID {
-	if nodeID == nil {
-		SetNodeInterface("")
-	}
+	SetNodeInterface("")
 
 	now, seq, err := GetTime()
 	if err != nil {


### PR DESCRIPTION
by moving nodeID check into SetNodeInterface() where mutex is used.

Fixes #41, but a better solution may be possible.