### PR TITLE
Fixed golint warnings

### DIFF
--- a/sql_test.go
+++ b/sql_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func TestScan(t *testing.T) {
-	var stringTest string = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
-	var byteTest []byte = Parse(stringTest)
-	var badTypeTest int = 6
-	var invalidTest string = "f47ac10b-58cc-0372-8567-0e02b2c3d4"
+	var (
+		stringTest  = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
+		byteTest    = []byte(Parse(stringTest))
+		badTypeTest = 6
+		invalidTest = "f47ac10b-58cc-0372-8567-0e02b2c3d4"
+	)
 
 	// sunny day tests
 

--- a/time.go
+++ b/time.go
@@ -29,7 +29,7 @@ func GetTime() (Time, uint16, error) { return guuid.GetTime() }
 // for
 func ClockSequence() int { return guuid.ClockSequence() }
 
-// SetClockSeq sets the clock sequence to the lower 14 bits of seq.  Setting to
+// SetClockSequence sets the clock sequence to the lower 14 bits of seq.  Setting to
 // -1 causes a new sequence to be generated.
 func SetClockSequence(seq int) { guuid.SetClockSequence(seq) }
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -261,7 +261,7 @@ func testDCE(t *testing.T, name string, uuid UUID, domain Domain, id uint32) {
 	}
 	if v, ok := uuid.Id(); !ok || v != id {
 		if !ok {
-			t.Errorf("%s: %d: Id failed", name, uuid)
+			t.Errorf("%s: %d: ID failed", name, uuid)
 		} else {
 			t.Errorf("%s: %s: expected id %d, got %d", name, uuid, id, v)
 		}
@@ -277,7 +277,7 @@ func TestDCE(t *testing.T) {
 type badRand struct{}
 
 func (r badRand) Read(buf []byte) (int, error) {
-	for i, _ := range buf {
+	for i := range buf {
 		buf[i] = byte(i)
 	}
 	return len(buf), nil

--- a/version4.go
+++ b/version4.go
@@ -6,7 +6,7 @@ package uuid
 
 import guuid "github.com/google/uuid"
 
-// Random returns a Random (Version 4) UUID or panics.
+// NewRandom returns a Random (Version 4) UUID or panics.
 //
 // The strength of the UUIDs is based on the strength of the crypto/rand
 // package.


### PR DESCRIPTION
Fixed:

1. dce.go:67:18: method Id should be ID
2. hash.go:15:2: don't use underscores in Go names; var NameSpace_DNS should be NameSpaceDNS
3. hash.go:16:2: don't use underscores in Go names; var NameSpace_URL should be NameSpaceURL
4. hash.go:17:2: don't use underscores in Go names; var NameSpace_OID should be NameSpaceOID
5. hash.go:18:2: don't use underscores in Go names; var NameSpace_X500 should be NameSpaceX500
6. sql_test.go:13:17: should omit type string from declaration of var stringTest; it will be inferred from the right-hand side
7. sql_test.go:15:18: should omit type int from declaration of var badTypeTest; it will be inferred from the right-hand side
8. sql_test.go:16:18: should omit type string from declaration of var invalidTest; it will be inferred from the right-hand side
9. time.go:32:1: comment on exported function SetClockSequence should be of the form "SetClockSequence ..."
10. uuid_test.go:280:9: should omit 2nd value from range; this loop is equivalent to `for i := range ...`
11. version4.go:9:1: comment on exported function NewRandom should be of the form "NewRandom ..."
